### PR TITLE
Fix build for 7.10

### DIFF
--- a/src/Numerical/Array/Layout/Base.hs
+++ b/src/Numerical/Array/Layout/Base.hs
@@ -74,7 +74,9 @@ import  qualified Control.Applicative as A
 import  qualified  Data.Foldable as F
 #endif
 
-
+#if MIN_VERSION_base(4,8,0)
+import Prelude hiding (foldl)
+#endif
 
 {-
 NB: may need to add some specialization for low rank indexing,

--- a/src/Numerical/Array/Storage.hs
+++ b/src/Numerical/Array/Storage.hs
@@ -65,16 +65,22 @@ instance VGM.MVector (BufferMut mode) a=> MBuffer mode a
 -- as the underlying storage representation.
 data Boxed
   deriving Typeable
+
+deriving instance Data Boxed
+
 -- | 'Unboxed' is the type index for 'Buffer's that use the unboxed data structure
 -- 'Data.Vector.Unboxed.Vector' as the underlying storage representation.
 data Unboxed
   deriving Typeable
+
+deriving instance Data Unboxed
 
 -- | 'Stored' is the type index for 'Buffer's that use the 'Foreign.Storable'
 -- for values, in pinned byte array  buffers, provided by 'Data.Vector.Storable'
 data Stored
   deriving Typeable
 
+deriving instance Data Stored
 
 type instance VG.Mutable (BufferPure sort) = BufferMut sort
 


### PR DESCRIPTION
I tested with 7.10.1 and 7.8.4. The Data deriving really need to be standalone because you can't derive Data when there is no constructor otherwise (in 7.10).
Signed-off-by: Moritz Kiefer <moritz.kiefer@purelyfunctional.org>